### PR TITLE
Add token usage to responses for Bedrock connector.

### DIFF
--- a/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Services/BedrockChatCompletionServiceTests.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon.UnitTests/Services/BedrockChatCompletionServiceTests.cs
@@ -106,8 +106,9 @@ public sealed class BedrockChatCompletionServiceTests
             {
                 URL = "https://bedrock-runtime.us-east-1.amazonaws.com"
             });
+        var converseResponse = this.CreateConverseResponse("Hello, world!", ConversationRole.Assistant);
         mockBedrockApi.Setup(m => m.ConverseAsync(It.IsAny<ConverseRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(this.CreateConverseResponse("Hello, world!", ConversationRole.Assistant));
+            .ReturnsAsync(converseResponse);
         var kernel = Kernel.CreateBuilder().AddBedrockChatCompletionService(modelId, mockBedrockApi.Object).Build();
         var service = kernel.GetRequiredService<IChatCompletionService>();
         var chatHistory = CreateSampleChatHistory();
@@ -121,6 +122,7 @@ public sealed class BedrockChatCompletionServiceTests
         Assert.Single(result[0].Items);
         Assert.Equal("Hello, world!", result[0].Items[0].ToString());
         Assert.NotNull(result[0].InnerContent);
+        Assert.Equal(result[0].Metadata?["Usage"], converseResponse.Usage);
     }
 
     /// <summary>
@@ -170,6 +172,7 @@ public sealed class BedrockChatCompletionServiceTests
         Assert.Equal(iterations, output.Count);
         Assert.NotNull(service.GetModelId());
         Assert.NotNull(service.Attributes);
+        Assert.Contains(output, c => c.Metadata?["Usage"] is TokenUsage);
     }
 
     /// <summary>

--- a/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Core/Clients/BedrockChatCompletionClient.cs
+++ b/dotnet/src/Connectors/Connectors.Amazon/Bedrock/Core/Clients/BedrockChatCompletionClient.cs
@@ -130,7 +130,11 @@ internal sealed class BedrockChatCompletionClient
             {
                 Role = BedrockClientUtilities.MapConversationRoleToAuthorRole(message.Role.Value),
                 Items = CreateChatMessageContentItemCollection(message.Content),
-                InnerContent = response
+                InnerContent = response,
+                Metadata = new Dictionary<string, object?>
+                {
+                    { "Usage", response.Usage }
+                }
             }
         ];
     }
@@ -198,6 +202,18 @@ internal sealed class BedrockChatCompletionClient
                 // Convert output to semantic kernel's StreamingChatMessageContent
                 var c = deltaEvent?.Delta.Text;
                 var content = new StreamingChatMessageContent(AuthorRole.Assistant, c, deltaEvent);
+                streamedContents?.Add(content);
+                yield return content;
+            }
+
+            if (chunk is ConverseStreamMetadataEvent metadataEvent)
+            {
+                var metadata = new Dictionary<string, object?>
+                {
+                    { "Usage", metadataEvent.Usage }
+                };
+
+                var content = new StreamingChatMessageContent(AuthorRole.Assistant, "", metadataEvent, metadata: metadata);
                 streamedContents?.Add(content);
                 yield return content;
             }

--- a/dotnet/src/IntegrationTests/Connectors/Amazon/Bedrock/BedrockChatCompletionTests.cs
+++ b/dotnet/src/IntegrationTests/Connectors/Amazon/Bedrock/BedrockChatCompletionTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Amazon.BedrockRuntime.Model;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Xunit;
@@ -39,9 +42,9 @@ public class BedrockChatCompletionTests
         var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
 
         // Act
-        var response = await chatCompletionService.GetChatMessageContentsAsync(chatHistory).ConfigureAwait(true);
+        var messages = await chatCompletionService.GetChatMessageContentsAsync(chatHistory).ConfigureAwait(true);
         string output = "";
-        foreach (var message in response)
+        foreach (var message in messages)
         {
             output += message.Content;
             Assert.NotNull(message.InnerContent);
@@ -50,9 +53,12 @@ public class BedrockChatCompletionTests
 
         // Assert
         Assert.NotNull(output);
-        Assert.True(response.Count > 0);
+        Assert.True(messages.Count > 0);
         Assert.Equal(4, chatHistory.Count);
-        Assert.Equal(AuthorRole.Assistant, chatHistory[3].Role);
+
+        var assistantMessage = messages[0];
+        Assert.Equal(AuthorRole.Assistant, assistantMessage.Role);
+        Assert.NotNull(assistantMessage.Metadata?["Usage"] as TokenUsage);
     }
 
     [Theory(Skip = "For manual verification only")]
@@ -87,10 +93,15 @@ public class BedrockChatCompletionTests
         // Act
         var response = chatCompletionService.GetStreamingChatMessageContentsAsync(chatHistory).ConfigureAwait(true);
         string output = "";
+        List<IReadOnlyDictionary<string, object?>> metadataList = [];
         await foreach (var message in response)
         {
             output += message.Content;
             Assert.NotNull(message.InnerContent);
+            if (message.Metadata != null)
+            {
+                metadataList.Add(message.Metadata);
+            }
         }
         chatHistory.AddAssistantMessage(output);
 
@@ -99,5 +110,6 @@ public class BedrockChatCompletionTests
         Assert.Equal(4, chatHistory.Count);
         Assert.Equal(AuthorRole.Assistant, chatHistory[3].Role);
         Assert.False(string.IsNullOrEmpty(output));
+        Assert.Contains(metadataList, m => m["Usage"] is TokenUsage);
     }
 }


### PR DESCRIPTION
### Motivation and Context

Some connectors (for example OpenAI and Mistral) return token usage in `ChatMessageContent.Metadata`, which might be
used
later in application's logic (usually for request/usage limiting).

Adding token usage for Bedrock connector too.

Resolves #12168

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Added token usage to both: streaming and non-streaming methods.

Streaming method returns token usage at very end and as long as current contract uses `yield return`, I yield item with
empty content with attached usage.

Tried to do bare minimum to achieve the goal, like I saw some code formatting discrepancies under way, but did not fix
that.

### Contribution Checklist

I've ran as many tests as I could, but for quite a lot of integration tests I had no available infrastructure.

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows
  the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and
  the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts)
  raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
